### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 
    ```bash
    cd frontend
-   nmp install
+   npm install
    ```
 
 ### Windows
@@ -128,7 +128,7 @@
 
    ```bash
    cd frontend
-   nmp install
+   npm install
    ```
    
 **Можно работать!**


### PR DESCRIPTION
Никто не заметил, что в `README.md` вместо `npm`  было `nmp`.
(Я тоже)