### PR TITLE
New logic services

### DIFF
--- a/backend/backend/apps/bookings/models.py
+++ b/backend/backend/apps/bookings/models.py
@@ -1,4 +1,4 @@
-import datetime
+import datetime as dt
 
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -28,18 +28,10 @@ class Booking(models.Model):
     created = models.DateTimeField()
 
     @staticmethod
-    def _convert_to_local(dt: datetime.datetime) -> datetime.datetime:
-        if timezone.is_naive(dt):
-            raise ValueError("Datetime must be timezone-aware (USE_TZ=True)")
-        return dt.astimezone(timezone.get_current_timezone())
-
-    @property
-    def start_datetime_local(self) -> datetime:
-        return self._convert_to_local(self.start_datetime)
-
-    @property
-    def end_datetime_local(self) -> datetime:
-        return self._convert_to_local(self.end_datetime)
+    def dt_to_local(value: dt.datetime) -> dt.datetime:
+        if timezone.is_naive(value):
+            raise ValueError("Value [Datetime] must be timezone-aware (USE_TZ=True)")
+        return value.astimezone(timezone.get_current_timezone())
 
     def is_booking_time_available(self) -> bool:
         buffer_time = SaunaConfig.get().min_time_between_bookings
@@ -69,8 +61,8 @@ class Booking(models.Model):
             )
 
         if (self.end_datetime.date() != self.date and
-            not (self.end_datetime.time() == datetime.time(0)
-                and self.end_datetime.date == self.date + datetime.timedelta(days=1))):
+            not (self.end_datetime.time() == dt.time(0)
+                and self.end_datetime.date == self.date + dt.timedelta(days=1))):
             raise ValidationError(
                 _("The end date of the booking must match the date of the booking itself or 0:00 of the next day."),
                 params={"end_time.date()": self.end_datetime.date(),
@@ -114,8 +106,10 @@ class Booking(models.Model):
             )
 
     def __str__(self) -> str:
+        """
+        TODO: may be change Customer.__str__ because there are can be a lot of simular nicknames
+        """
         return "{customer} on {date} [{start} - {end}]".format(customer=self.customer,
                                                                date=self.date,
-                                                               start=self.start_datetime_local.strftime("%H:%M"),
-                                                               end=self.end_datetime_local.strftime("%H:%M"))
-        # may be change Customer.__str__ because there are can be a lot of simular nicknames
+                                                               start=self.dt_to_local(self.start_datetime).strftime("%H:%M"),
+                                                               end=self.dt_to_local(self.end_datetime).strftime("%H:%M"))

--- a/backend/backend/apps/bookings/models.py
+++ b/backend/backend/apps/bookings/models.py
@@ -31,7 +31,7 @@ class Booking(models.Model):
     def dt_to_local(value: dt.datetime) -> dt.datetime:
         if timezone.is_naive(value):
             raise ValueError("Value [Datetime] must be timezone-aware (USE_TZ=True)")
-        return value.astimezone(timezone.get_current_timezone())
+        return value.astimezone(timezone.get_default_timezone())
 
     def is_booking_time_available(self) -> bool:
         buffer_time = SaunaConfig.get().min_time_between_bookings

--- a/backend/backend/apps/bookings/models.py
+++ b/backend/backend/apps/bookings/models.py
@@ -1,7 +1,8 @@
-import datetime
+from datetime import datetime
 
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 import backend.apps.bookings.validators as validators
@@ -115,5 +116,8 @@ class Booking(models.Model):
             )
 
     def __str__(self) -> str:
-        return f"{self.customer} on {self.date} [{self.start_datetime} - {self.end_datetime}]"
+        return "{customer} on {date} [{start} - {end}]".format(customer=self.customer,
+                                                               date=self.date,
+                                                               start=self.start_datetime_local.strftime("%H:%M"),
+                                                               end=self.end_datetime_local.strftime("%H:%M"))
         # may be change Customer.__str__ because there are can be a lot of simular nicknames

--- a/backend/backend/apps/bookings/models.py
+++ b/backend/backend/apps/bookings/models.py
@@ -26,6 +26,22 @@ class Booking(models.Model):
     preferred_contact_method = models.CharField(max_length=10, choices=ContactMethod)
     created = models.DateTimeField()
 
+    @staticmethod
+    def _convert_to_local(dt: datetime | None) -> datetime | None:
+        if dt is None:
+            return None
+        if timezone.is_naive(dt):
+            raise ValueError("Datetime must be timezone-aware (USE_TZ=True)")
+        return dt.astimezone(timezone.get_current_timezone())
+
+    @property
+    def start_datetime_local(self) -> datetime | None:
+        return self._convert_to_local(self.start_datetime)
+
+    @property
+    def end_datetime_local(self) -> datetime | None:
+        return self._convert_to_local(self.end_datetime)
+
     def is_booking_time_available(self) -> bool:
         buffer_time = SaunaConfig.get().min_time_between_bookings
 

--- a/backend/backend/apps/bookings/models.py
+++ b/backend/backend/apps/bookings/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime
 
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -28,19 +28,17 @@ class Booking(models.Model):
     created = models.DateTimeField()
 
     @staticmethod
-    def _convert_to_local(dt: datetime | None) -> datetime | None:
-        if dt is None:
-            return None
+    def _convert_to_local(dt: datetime.datetime) -> datetime.datetime:
         if timezone.is_naive(dt):
             raise ValueError("Datetime must be timezone-aware (USE_TZ=True)")
         return dt.astimezone(timezone.get_current_timezone())
 
     @property
-    def start_datetime_local(self) -> datetime | None:
+    def start_datetime_local(self) -> datetime:
         return self._convert_to_local(self.start_datetime)
 
     @property
-    def end_datetime_local(self) -> datetime | None:
+    def end_datetime_local(self) -> datetime:
         return self._convert_to_local(self.end_datetime)
 
     def is_booking_time_available(self) -> bool:

--- a/backend/backend/apps/bookings/serializers.py
+++ b/backend/backend/apps/bookings/serializers.py
@@ -1,0 +1,22 @@
+from django.utils.timezone import get_current_timezone
+from rest_framework import serializers
+
+from backend.services.booking_service import TimeSlot
+
+
+class TimeSlotSerializer(serializers.Serializer):
+    start = serializers.SerializerMethodField()
+    end = serializers.SerializerMethodField()
+
+    def get_start(self, obj: TimeSlot) -> str:
+        local_start = obj.start.astimezone(get_current_timezone())
+        return local_start.strftime("%H:%M")
+
+    def get_end(self, obj: TimeSlot) -> str:
+        local_end = obj.end.astimezone(get_current_timezone())
+        return local_end.strftime("%H:%M")
+
+
+class FreeSlotsResponseSerializer(serializers.Serializer):
+    date = serializers.DateField()
+    free_slots = TimeSlotSerializer(many=True)

--- a/backend/backend/apps/bookings/serializers.py
+++ b/backend/backend/apps/bookings/serializers.py
@@ -5,16 +5,12 @@ from backend.services.booking_service import TimeSlot
 
 
 class TimeSlotSerializer(serializers.Serializer):
-    start = serializers.SerializerMethodField()
-    end = serializers.SerializerMethodField()
-
-    def get_start(self, obj: TimeSlot) -> str:
-        local_start = obj.start.astimezone(get_default_timezone())
-        return local_start.strftime("%H:%M")
-
-    def get_end(self, obj: TimeSlot) -> str:
-        local_end = obj.end.astimezone(get_default_timezone())
-        return local_end.strftime("%H:%M")
+    def to_representation(self, obj: TimeSlot) -> dict:
+        tz = get_default_timezone()
+        return {
+            "start": obj.start.astimezone(tz=tz).strftime("%H:%M"),
+            "end": obj.end.astimezone(tz=tz).strftime("%H:%M"),
+        }
 
 
 class FreeSlotsResponseSerializer(serializers.Serializer):

--- a/backend/backend/apps/bookings/serializers.py
+++ b/backend/backend/apps/bookings/serializers.py
@@ -1,4 +1,4 @@
-from django.utils.timezone import get_current_timezone
+from django.utils.timezone import get_default_timezone
 from rest_framework import serializers
 
 from backend.services.booking_service import TimeSlot
@@ -9,11 +9,11 @@ class TimeSlotSerializer(serializers.Serializer):
     end = serializers.SerializerMethodField()
 
     def get_start(self, obj: TimeSlot) -> str:
-        local_start = obj.start.astimezone(get_current_timezone())
+        local_start = obj.start.astimezone(get_default_timezone())
         return local_start.strftime("%H:%M")
 
     def get_end(self, obj: TimeSlot) -> str:
-        local_end = obj.end.astimezone(get_current_timezone())
+        local_end = obj.end.astimezone(get_default_timezone())
         return local_end.strftime("%H:%M")
 
 

--- a/backend/backend/apps/bookings/urls.py
+++ b/backend/backend/apps/bookings/urls.py
@@ -5,5 +5,5 @@ from .views import FreeBookingTime
 app_name = "bookings"
 
 urlpatterns = [
-    path("get-free-booking-time/", FreeBookingTime.as_view(), name="get_free_booking_time"),
+    path("free-slots/", FreeBookingTime.as_view(), name="free_slots"),
 ]

--- a/backend/backend/apps/bookings/views.py
+++ b/backend/backend/apps/bookings/views.py
@@ -7,6 +7,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from backend.apps.authentication.auth import APIKeyHeaderAuthentication
+from backend.apps.bookings.serializers import FreeSlotsResponseSerializer
+from backend.services.booking_service import get_free_booking_time
 
 
 class FreeBookingTime(APIView):
@@ -16,15 +18,14 @@ class FreeBookingTime(APIView):
     def get(self, request: Request) -> Response:
         date_str = request.query_params.get("date")
         if date_str is None:
-            return Response({"error": "No data provided"},
+            return Response({"error": "No date provided"},
                             status=status.HTTP_400_BAD_REQUEST)
         try:
-            date_obj = datetime.strptime(date_str, "%Y-%m-%d")  # Format: "2023-10-20"
+            date_obj = datetime.strptime(date_str, "%Y-%m-%d").date()
         except (ValueError, TypeError):
             return Response({"error": "Invalid date format. Use YYYY-MM-DD"},
                             status=status.HTTP_400_BAD_REQUEST)
 
-        # The idea of business logic
-        _ = date_obj
-        intervals = []
-        return Response({"free_booking_time": intervals})
+        free_slots = get_free_booking_time(date_obj)
+        serializer = FreeSlotsResponseSerializer(free_slots)
+        return Response(serializer.data)

--- a/backend/backend/apps/core/models.py
+++ b/backend/backend/apps/core/models.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from typing import Any
 
 from django.core.cache import cache
@@ -30,6 +31,13 @@ class SaunaConfig(models.Model):
             config = cls.objects.first() or cls.objects.create()
             cache.set("sauna_config", config)
         return config
+
+    def get_opening_and_closing_dt(self, date: dt.date) -> tuple[dt.datetime, dt.datetime]:
+        opening = timezone.make_aware(dt.datetime.combine(date, self.opening_time)).astimezone(dt.UTC)
+        closing = timezone.make_aware(dt.datetime.combine(date, self.closing_time)).astimezone(dt.UTC)
+        if closing <= opening:
+            closing += dt.timedelta(days=1)
+        return opening, closing
 
     def __str__(self) -> str:
         return f"Config on {self.created.astimezone(timezone.get_default_timezone()).strftime('%d.%m.%Y %H:%M')}"

--- a/backend/backend/apps/core/models.py
+++ b/backend/backend/apps/core/models.py
@@ -32,6 +32,4 @@ class SaunaConfig(models.Model):
         return config
 
     def __str__(self) -> str:
-        return f"Config on {self.created
-        .astimezone(timezone.get_default_timezone())
-        .strftime('%d.%m.%Y %H:%M')}"
+        return f"Config on {self.created.astimezone(timezone.get_default_timezone()).strftime('%d.%m.%Y %H:%M')}"

--- a/backend/backend/apps/core/models.py
+++ b/backend/backend/apps/core/models.py
@@ -33,8 +33,8 @@ class SaunaConfig(models.Model):
         return config
 
     def get_opening_and_closing_dt(self, date: dt.date) -> tuple[dt.datetime, dt.datetime]:
-        opening = timezone.make_aware(dt.datetime.combine(date, self.opening_time)).astimezone(dt.UTC)
-        closing = timezone.make_aware(dt.datetime.combine(date, self.closing_time)).astimezone(dt.UTC)
+        opening = timezone.make_aware(dt.datetime.combine(date, self.opening_time))
+        closing = timezone.make_aware(dt.datetime.combine(date, self.closing_time))
         if closing <= opening:
             closing += dt.timedelta(days=1)
         return opening, closing

--- a/backend/backend/services/booking_service.py
+++ b/backend/backend/services/booking_service.py
@@ -2,6 +2,8 @@ import datetime as dt
 from collections.abc import Iterator
 from dataclasses import dataclass
 
+from django.utils.timezone import make_aware
+
 from backend.apps.bookings.models import Booking
 from backend.apps.core.models import SaunaConfig
 
@@ -14,40 +16,28 @@ class TimeSlot:
     def duration(self) -> dt.timedelta:
         return self.end - self.start
 
-    def as_dict(self, tz: dt.tzinfo | None = None) -> dict:
-        start = self.start.astimezone(tz) if tz else self.start
-        end = self.end.astimezone(tz) if tz else self.end
-        return {"start": start.strftime("%H:%M"),
-                "end": end.strftime("%H:%M")}
-
 
 @dataclass
 class FreeSlots:
     date: dt.date
-    slots: list[TimeSlot]
+    free_slots: list[TimeSlot]
 
     def add(self, time_slot: TimeSlot) -> None:
-        self.slots.append(time_slot)
+        self.free_slots.append(time_slot)
 
     def is_empty(self) -> bool:
-        return not self.slots
+        return not self.free_slots
 
     def total_duration(self) -> dt.timedelta:
-        return sum((slot.duration() for slot in self.slots), start=dt.timedelta())
-
-    def as_dict(self, tz: dt.tzinfo | None = None) -> dict:
-        return {
-            "date": self.date.isoformat(),
-            "free_slots": [slot.as_dict(tz=tz) for slot in self.slots]
-        }
+        return sum((slot.duration() for slot in self.free_slots), start=dt.timedelta())
 
     def __iter__(self) -> Iterator[TimeSlot]:
-        return iter(self.slots)
+        return iter(self.free_slots)
 
 
 def _get_opening_and_closing(booking_date: dt.date, sauna_config: SaunaConfig) -> tuple[dt.datetime, dt.datetime]:
-    opening = dt.datetime.combine(booking_date, sauna_config.opening_time).replace(tzinfo=dt.UTC)
-    closing = dt.datetime.combine(booking_date, sauna_config.closing_time).replace(tzinfo=dt.UTC)
+    opening = make_aware(dt.datetime.combine(booking_date, sauna_config.opening_time)).astimezone(dt.UTC)
+    closing = make_aware(dt.datetime.combine(booking_date, sauna_config.closing_time)).astimezone(dt.UTC)
     if closing <= opening:
         closing += dt.timedelta(days=1)
     return opening, closing
@@ -75,7 +65,7 @@ def get_free_booking_time(booking_date: dt.date) -> FreeSlots:
     next_time = _get_earliest_start(booking_date, opening, sauna_config)
 
     bookings = Booking.objects.filter(date=booking_date).order_by("start_datetime")
-    free_slots = FreeSlots(booking_date, slots=[])
+    free_slots = FreeSlots(booking_date, free_slots=[])
 
     for booking in bookings:
         start_buf = booking.start_datetime - sauna_config.min_time_between_bookings
@@ -87,6 +77,7 @@ def get_free_booking_time(booking_date: dt.date) -> FreeSlots:
         next_time = max(next_time, end_buf)
 
     if closing - next_time >= sauna_config.min_booking_time:
+
         free_slots.add(TimeSlot(start=next_time, end=closing))
 
     return free_slots

--- a/backend/backend/services/booking_service.py
+++ b/backend/backend/services/booking_service.py
@@ -43,14 +43,6 @@ def _get_opening_and_closing(booking_date: dt.date, sauna_config: SaunaConfig) -
     return opening, closing
 
 
-def _get_earliest_start(booking_date: dt.date, opening: dt.datetime, sauna_config: SaunaConfig) -> dt.datetime:
-    now = dt.datetime.now(dt.UTC)
-    if booking_date == now.date():
-        earliest = now + sauna_config.min_time_from_now_to_booking
-        return max(opening, earliest)
-    return opening
-
-
 def get_free_booking_time(booking_date: dt.date) -> FreeSlots:
     """
     TODO: BE SURE TO REVIEW
@@ -62,7 +54,7 @@ def get_free_booking_time(booking_date: dt.date) -> FreeSlots:
     """
     sauna_config = SaunaConfig.get()
     opening, closing = _get_opening_and_closing(booking_date, sauna_config)
-    next_time = _get_earliest_start(booking_date, opening, sauna_config)
+    next_time = opening
 
     bookings = Booking.objects.filter(date=booking_date).order_by("start_datetime")
     free_slots = FreeSlots(booking_date, free_slots=[])

--- a/backend/backend/services/booking_service.py
+++ b/backend/backend/services/booking_service.py
@@ -1,60 +1,92 @@
-import datetime
-
-from django.utils import timezone
+import datetime as dt
+from collections.abc import Iterator
+from dataclasses import dataclass
 
 from backend.apps.bookings.models import Booking
 from backend.apps.core.models import SaunaConfig
 
 
-def get_free_booking_time(booking_date: datetime.date) -> list[tuple[str, str]]:
+@dataclass
+class TimeSlot:
+    start: dt.datetime
+    end: dt.datetime
+
+    def duration(self) -> dt.timedelta:
+        return self.end - self.start
+
+    def as_dict(self, tz: dt.tzinfo | None = None) -> dict:
+        start = self.start.astimezone(tz) if tz else self.start
+        end = self.end.astimezone(tz) if tz else self.end
+        return {"start": start.strftime("%H:%M"),
+                "end": end.strftime("%H:%M")}
+
+
+@dataclass
+class FreeSlots:
+    date: dt.date
+    slots: list[TimeSlot]
+
+    def add(self, time_slot: TimeSlot) -> None:
+        self.slots.append(time_slot)
+
+    def is_empty(self) -> bool:
+        return not self.slots
+
+    def total_duration(self) -> dt.timedelta:
+        return sum((slot.duration() for slot in self.slots), start=dt.timedelta())
+
+    def as_dict(self, tz: dt.tzinfo | None = None) -> dict:
+        return {
+            "date": self.date.isoformat(),
+            "free_slots": [slot.as_dict(tz=tz) for slot in self.slots]
+        }
+
+    def __iter__(self) -> Iterator[TimeSlot]:
+        return iter(self.slots)
+
+
+def _get_opening_and_closing(booking_date: dt.date, sauna_config: SaunaConfig) -> tuple[dt.datetime, dt.datetime]:
+    opening = dt.datetime.combine(booking_date, sauna_config.opening_time).replace(tzinfo=dt.UTC)
+    closing = dt.datetime.combine(booking_date, sauna_config.closing_time).replace(tzinfo=dt.UTC)
+    if closing <= opening:
+        closing += dt.timedelta(days=1)
+    return opening, closing
+
+
+def _get_earliest_start(booking_date: dt.date, opening: dt.datetime, sauna_config: SaunaConfig) -> dt.datetime:
+    now = dt.datetime.now(dt.UTC)
+    if booking_date == now.date():
+        earliest = now + sauna_config.min_time_from_now_to_booking
+        return max(opening, earliest)
+    return opening
+
+
+def get_free_booking_time(booking_date: dt.date) -> FreeSlots:
     """
     TODO: BE SURE TO REVIEW
     Returns a list of time intervals (HH: MM), in which it is possible to create a new reservation.
-
     Rules:
       1. The interval of the new booking should differ from the existing booking at least in min_time_between_bookings.
       2. You can not book earlier than the current time + min_time_from_now_to_booking.
       3. If the bathhouse closes after midnight, we take into account the transition the next day.
     """
-    # we load the parameters from the configuration
     sauna_config = SaunaConfig.get()
+    opening, closing = _get_opening_and_closing(booking_date, sauna_config)
+    next_time = _get_earliest_start(booking_date, opening, sauna_config)
 
-    # we form absolute points of discovery and closure
-    opening_dt = (datetime.datetime.combine(booking_date, sauna_config.opening_time).
-                  astimezone(timezone.get_current_timezone()))
-    closing_dt = (datetime.datetime.combine(booking_date, sauna_config.closing_time).
-                  astimezone(timezone.get_current_timezone()))
-    # If closing later than midnight, we transfer the next day
-    if closing_dt <= opening_dt:
-        closing_dt += datetime.timedelta(days=1)
-
-    # we determine the minimum possible start time
-    now = (datetime.datetime.now().astimezone(timezone.get_current_timezone()))
-    if booking_date == now.date():
-        earliest_start = now + sauna_config.min_time_from_now_to_booking
-        # Не раньше открытия
-        next_time = max(earliest_start, opening_dt)
-    else:
-        next_time = opening_dt
-
-    # we collect existing armor on the date, sorting at the beginning
     bookings = Booking.objects.filter(date=booking_date).order_by("start_datetime")
-    free_slots: list[tuple[str, str]] = []
+    free_slots = FreeSlots(booking_date, slots=[])
 
     for booking in bookings:
-        # we take into account the buffer before and after the existing armor
-        start_buf = booking.start_datetime_local - sauna_config.min_time_between_bookings
-        end_buf = booking.end_datetime_local + sauna_config.min_time_between_bookings
+        start_buf = booking.start_datetime - sauna_config.min_time_between_bookings
+        end_buf = booking.end_datetime + sauna_config.min_time_between_bookings
 
-        # if there is a sufficient interval between Next_Time and the beginning of the armor without a buffer
         if start_buf - next_time >= sauna_config.min_booking_time:
-            free_slots.append((next_time.strftime("%H:%M"), start_buf.strftime("%H:%M")))
+            free_slots.add(TimeSlot(start=next_time, end=start_buf))
 
-        # we move next_time by the end of the buffer
         next_time = max(next_time, end_buf)
 
-    # check the interval before closing
-    if closing_dt - next_time >= sauna_config.min_booking_time:
-        free_slots.append((next_time.strftime("%H:%M"), closing_dt.strftime("%H:%M")))
+    if closing - next_time >= sauna_config.min_booking_time:
+        free_slots.add(TimeSlot(start=next_time, end=closing))
 
     return free_slots

--- a/backend/backend/services/booking_service.py
+++ b/backend/backend/services/booking_service.py
@@ -1,0 +1,38 @@
+import datetime
+
+from django.utils import timezone
+
+from backend.apps.bookings.models import Booking
+from backend.apps.core.models import SaunaConfig
+
+
+def get_free_booking_time(booking_date: datetime.date) -> list[tuple[str, str]]:
+    sauna_config = SaunaConfig.get()
+    bookings = Booking.objects.filter(date=booking_date)
+
+    opening_time = (datetime.datetime.combine(booking_date, sauna_config.opening_time).
+                    astimezone(timezone.get_current_timezone()))
+    closing_time = (datetime.datetime.combine(booking_date, sauna_config.closing_time).
+                    astimezone(timezone.get_current_timezone()))
+
+    if closing_time < opening_time:
+        closing_time += datetime.timedelta(days=1)
+
+    if datetime.date.today() == booking_date:
+        next_time = (datetime.datetime.now().astimezone(timezone.get_current_timezone()) +
+                     sauna_config.min_time_from_now_to_booking)
+    else:
+        next_time = opening_time
+
+    free_booking_time = []
+    for booking in bookings:
+        start_datetime = booking.start_datetime_local - sauna_config.min_time_between_bookings
+        end_datetime = booking.end_datetime_local + sauna_config.min_time_between_bookings
+        if (start_datetime - next_time) >= sauna_config.min_booking_time:
+            free_booking_time.append((next_time.strftime("%H:%M"), start_datetime.strftime("%H:%M")))
+        next_time = end_datetime
+
+    if (closing_time - next_time) >= sauna_config.min_booking_time:
+        free_booking_time.append((next_time.strftime("%H:%M"), closing_time.strftime("%H:%M")))
+
+    return free_booking_time

--- a/backend/backend/services/booking_service.py
+++ b/backend/backend/services/booking_service.py
@@ -7,32 +7,54 @@ from backend.apps.core.models import SaunaConfig
 
 
 def get_free_booking_time(booking_date: datetime.date) -> list[tuple[str, str]]:
+    """
+    TODO: BE SURE TO REVIEW
+    Returns a list of time intervals (HH: MM), in which it is possible to create a new reservation.
+
+    Rules:
+      1. The interval of the new armor should differ from the existing armor at least in min_time_between_bookings.
+      2. You can not book earlier than the current time + min_time_from_now_to_booking.
+      3. If the bathhouse closes after midnight, we take into account the transition the next day.
+    """
+    # we load the parameters from the configuration
     sauna_config = SaunaConfig.get()
-    bookings = Booking.objects.filter(date=booking_date)
 
-    opening_time = (datetime.datetime.combine(booking_date, sauna_config.opening_time).
-                    astimezone(timezone.get_current_timezone()))
-    closing_time = (datetime.datetime.combine(booking_date, sauna_config.closing_time).
-                    astimezone(timezone.get_current_timezone()))
+    # we form absolute points of discovery and closure
+    opening_dt = (datetime.datetime.combine(booking_date, sauna_config.opening_time).
+                  astimezone(timezone.get_current_timezone()))
+    closing_dt = (datetime.datetime.combine(booking_date, sauna_config.closing_time).
+                  astimezone(timezone.get_current_timezone()))
+    # If closing later than midnight, we transfer the next day
+    if closing_dt <= opening_dt:
+        closing_dt += datetime.timedelta(days=1)
 
-    if closing_time < opening_time:
-        closing_time += datetime.timedelta(days=1)
-
-    if datetime.date.today() == booking_date:
-        next_time = (datetime.datetime.now().astimezone(timezone.get_current_timezone()) +
-                     sauna_config.min_time_from_now_to_booking)
+    # we determine the minimum possible start time
+    now = (datetime.datetime.now().astimezone(timezone.get_current_timezone()))
+    if booking_date == now.date():
+        earliest_start = now + sauna_config.min_time_from_now_to_booking
+        # Не раньше открытия
+        next_time = max(earliest_start, opening_dt)
     else:
-        next_time = opening_time
+        next_time = opening_dt
 
-    free_booking_time = []
+    # we collect existing armor on the date, sorting at the beginning
+    bookings = Booking.objects.filter(date=booking_date).order_by("start_datetime")
+    free_slots: list[tuple[str, str]] = []
+
     for booking in bookings:
-        start_datetime = booking.start_datetime_local - sauna_config.min_time_between_bookings
-        end_datetime = booking.end_datetime_local + sauna_config.min_time_between_bookings
-        if (start_datetime - next_time) >= sauna_config.min_booking_time:
-            free_booking_time.append((next_time.strftime("%H:%M"), start_datetime.strftime("%H:%M")))
-        next_time = end_datetime
+        # we take into account the buffer before and after the existing armor
+        start_buf = booking.start_datetime_local - sauna_config.min_time_between_bookings
+        end_buf = booking.end_datetime_local + sauna_config.min_time_between_bookings
 
-    if (closing_time - next_time) >= sauna_config.min_booking_time:
-        free_booking_time.append((next_time.strftime("%H:%M"), closing_time.strftime("%H:%M")))
+        # if there is a sufficient interval between Next_Time and the beginning of the armor without a buffer
+        if start_buf - next_time >= sauna_config.min_booking_time:
+            free_slots.append((next_time.strftime("%H:%M"), start_buf.strftime("%H:%M")))
 
-    return free_booking_time
+        # we move next_time by the end of the buffer
+        next_time = max(next_time, end_buf)
+
+    # check the interval before closing
+    if closing_dt - next_time >= sauna_config.min_booking_time:
+        free_slots.append((next_time.strftime("%H:%M"), closing_dt.strftime("%H:%M")))
+
+    return free_slots

--- a/backend/backend/services/booking_service.py
+++ b/backend/backend/services/booking_service.py
@@ -43,7 +43,7 @@ def get_free_booking_time(booking_date: dt.date) -> FreeSlots:
       3. If the bathhouse closes after midnight, we take into account the transition the next day.
     """
     sauna_config = SaunaConfig.get()
-    opening, closing = SaunaConfig.get_opening_and_closing_dt(booking_date)
+    opening, closing = sauna_config.get_opening_and_closing_dt(booking_date)
     next_time = opening
 
     bookings = Booking.objects.filter(date=booking_date).order_by("start_datetime")
@@ -59,7 +59,6 @@ def get_free_booking_time(booking_date: dt.date) -> FreeSlots:
         next_time = max(next_time, end_buf)
 
     if closing - next_time >= sauna_config.min_booking_time:
-
         free_slots.add(TimeSlot(start=next_time, end=closing))
 
     return free_slots

--- a/backend/backend/services/booking_service.py
+++ b/backend/backend/services/booking_service.py
@@ -35,12 +35,12 @@ class FreeSlots:
 
 def get_free_booking_time(booking_date: dt.date) -> FreeSlots:
     """
-    TODO: BE SURE TO REVIEW
-    Returns a list of time intervals (HH: MM), in which it is possible to create a new reservation.
+    Returns a FreeSlots dataclass instance containing available time intervals
+    (TimeSlot objects) for creating new reservations.
     Rules:
-      1. The interval of the new booking should differ from the existing booking at least in min_time_between_bookings.
-      2. You can not book earlier than the current time + min_time_from_now_to_booking.
-      3. If the bathhouse closes after midnight, we take into account the transition the next day.
+      1. Each available interval must be separated from existing bookings
+         by at least `min_time_between_bookings`.
+      2. If the bathhouse closes after midnight, the closing time is treated as the next day's datetime.
     """
     sauna_config = SaunaConfig.get()
     opening, closing = sauna_config.get_opening_and_closing_dt(booking_date)

--- a/backend/backend/services/booking_service.py
+++ b/backend/backend/services/booking_service.py
@@ -2,8 +2,6 @@ import datetime as dt
 from collections.abc import Iterator
 from dataclasses import dataclass
 
-from django.utils.timezone import make_aware
-
 from backend.apps.bookings.models import Booking
 from backend.apps.core.models import SaunaConfig
 
@@ -35,14 +33,6 @@ class FreeSlots:
         return iter(self.free_slots)
 
 
-def _get_opening_and_closing(booking_date: dt.date, sauna_config: SaunaConfig) -> tuple[dt.datetime, dt.datetime]:
-    opening = make_aware(dt.datetime.combine(booking_date, sauna_config.opening_time)).astimezone(dt.UTC)
-    closing = make_aware(dt.datetime.combine(booking_date, sauna_config.closing_time)).astimezone(dt.UTC)
-    if closing <= opening:
-        closing += dt.timedelta(days=1)
-    return opening, closing
-
-
 def get_free_booking_time(booking_date: dt.date) -> FreeSlots:
     """
     TODO: BE SURE TO REVIEW
@@ -53,7 +43,7 @@ def get_free_booking_time(booking_date: dt.date) -> FreeSlots:
       3. If the bathhouse closes after midnight, we take into account the transition the next day.
     """
     sauna_config = SaunaConfig.get()
-    opening, closing = _get_opening_and_closing(booking_date, sauna_config)
+    opening, closing = SaunaConfig.get_opening_and_closing_dt(booking_date)
     next_time = opening
 
     bookings = Booking.objects.filter(date=booking_date).order_by("start_datetime")

--- a/backend/backend/services/booking_service.py
+++ b/backend/backend/services/booking_service.py
@@ -12,7 +12,7 @@ def get_free_booking_time(booking_date: datetime.date) -> list[tuple[str, str]]:
     Returns a list of time intervals (HH: MM), in which it is possible to create a new reservation.
 
     Rules:
-      1. The interval of the new armor should differ from the existing armor at least in min_time_between_bookings.
+      1. The interval of the new booking should differ from the existing booking at least in min_time_between_bookings.
       2. You can not book earlier than the current time + min_time_from_now_to_booking.
       3. If the bathhouse closes after midnight, we take into account the transition the next day.
     """


### PR DESCRIPTION
# 🚀 Подключение бизнес-логики к API

### ✅ Подключена бизнес-логика расчёта свободного времени бронирования:
- Представление `FreeBookingTime` теперь использует сервисную функцию `get_free_booking_time()` из `booking_service.py`.
- Реализована сериализация ответа с помощью `FreeSlotsResponseSerializer` и `TimeSlotSerializer`.

### 🕒 Изменено поведение часового пояса:
- Вместо `get_current_timezone()` используется `get_default_timezone()` (всё поведение теперь жёстко ориентировано на глобальный `TIME_ZONE`, как и задумано для ситуации: одна баня - один сервер - одна зона).
- Это обеспечивает стабильную и предсказуемую работу без зависимости от запроса/пользователя.

## 📂 Файлы изменений:
- `booking_service.py`: добавлены `make_aware(...)` + `.astimezone(UTC)` для корректной локализации времени при расчётах.
- `views.py`: подключён сериализатор `FreeSlotsResponseSerializer`.
- `serializers.py`:  использование `get_default_timezone()` для локализации.
- `urls.py`: обновлена ручка `/get-free-booking-time/`.

## 📸 Пример использования:

```python
import requests
import json

url = "http://127.0.0.1:8000/api/get-free-booking-time/"
headers = {
    "X-API-Key": "api-secret-key"
}
params = {
    "date": "2025-04-03"
}

response = requests.get(url, params=params, headers=headers)
print(response.json())
```

**Пример ответа:**

```json
{
  "date": "2025-04-24",
  "free_slots": [
    {"start": "14:00", "end": "18:00"},
    {"start": "22:00", "end": "00:00"}
  ]
}
```
![Без имени](https://github.com/user-attachments/assets/13d6e971-7bdc-401b-a528-9c496cc92787)

 ---

## 💡 Почему это важно:
- Представление теперь возвращает **корректные локализованные интервалы**, соответствующие настройкам `SaunaConfig`.
- Использование `get_default_timezone()` устранило неоднозначности в локализации и сделало поведение системы стабильным и безопасным.
- Бизнес-логика отделена в отдельный модуль, что упрощает тестирование и дальнейшее развитие.

## 📌 Планы на будущее:
- Добавить проверки на кратность интервалов (30 минут).
- Автоматизировать покрытие API автотестами (pytest + DRF).
- Подключить `@extend_schema` для генерации OpenAPI-документации.
