### PR TITLE
Add **/migrations in exclude ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ exclude = [
     "node_modules",
     "site-packages",
     "venv",
+    "**/migrations",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
# Исправление проверок от `RUFF`
Добавил в список исключений для проверки ruff-ом все файлы, что находятся в папках `migrations`