### PR TITLE
Fix 3 pyproject files situation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.0
+    rev: v0.12.7
     hooks:
-      - id: ruff
+      - id: ruff-check

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,3 +26,6 @@ ruff = "^0.12.5"
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+extend = "../ruff.toml"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,3 @@
-[tool.ruff]
 line-length = 88
 target-version = "py312"
 
@@ -33,8 +32,7 @@ exclude = [
     "**/migrations",
 ]
 
-[tool.ruff.lint]
-select = [
+lint.select = [
     "E", "F", "I",
     "Q",
     "W",
@@ -49,7 +47,7 @@ select = [
     "TCH",
     "ANN" # flake8-annotations
 ]
-ignore = ["E203", "E501"]  # comparable with Black
+lint.ignore = ["E203", "E501"]  # comparable with Black
 
-[tool.ruff.format]
+[format]
 quote-style = "double"

--- a/telegram-bot/api/routers.py
+++ b/telegram-bot/api/routers.py
@@ -4,9 +4,10 @@ from typing import Final
 from urllib.parse import urlparse
 
 from aiogram import Bot
-from bot.core import bot
 from decouple import config
 from fastapi import APIRouter, Depends
+
+from bot.core import bot
 
 parsed_url = urlparse(config("BOT_API_URL"))
 bot_api_router = APIRouter(prefix=parsed_url.path)

--- a/telegram-bot/bot/handlers.py
+++ b/telegram-bot/bot/handlers.py
@@ -11,10 +11,10 @@ from datetime import datetime
 
 from aiogram.filters import Command
 from aiogram.types import Message
-from client.http_client import APIClient
 from decouple import config
 
 from bot.core import dp
+from client.http_client import APIClient
 
 # TODO: make it smarter (use singleton or Dependency injection or something else)
 client = APIClient(config("FORTUNA_API_URL"), config("BACKEND_API_SECRET_KEY"))

--- a/telegram-bot/bot/start.py
+++ b/telegram-bot/bot/start.py
@@ -1,6 +1,5 @@
-from logger import get_logger
-
 from bot.core import bot, dp
+from logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/telegram-bot/client/http_client.py
+++ b/telegram-bot/client/http_client.py
@@ -1,8 +1,8 @@
 import httpx
 import pydantic
-from logger import get_logger
 
 from client.scemas import FreeSlotsResponse
+from logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/telegram-bot/main.py
+++ b/telegram-bot/main.py
@@ -2,13 +2,14 @@ import asyncio
 from urllib.parse import urlparse
 
 import uvicorn
+from decouple import config
+from fastapi import FastAPI
+
 from api.routers import bot_api_router
 
 # Register handlers. Temporary solution
 from bot import handlers  # noqa: F401
 from bot.start import start_bot
-from decouple import config
-from fastapi import FastAPI
 from logger import get_logger
 
 logger = get_logger(__name__)

--- a/telegram-bot/pyproject.toml
+++ b/telegram-bot/pyproject.toml
@@ -26,3 +26,6 @@ ruff = "^0.12.5"
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+extend = "../ruff.toml"


### PR DESCRIPTION
# Что сделал

Разрешил #48.

# Как решил

Конфигурацию `ruff` можно хранить в двух файлах: в `pyproject.toml` и в `ruff.toml`.

- Решил просто переименовать `./pyproject.toml` в `ruff.toml` и немного поменял его синтаксис.
- Добавил в `backend/pyproject.toml` и в `telegram-bot/pyproject.toml` ссылку на этот файл конфигурации, чтобы `ruff` не потерялся.
- Почему-то пришлось еще раз прогнать `ruff`, так как появились новые ошибки линтинга

# Ничего ли не сломалось

Сделал проверки:
- `pre-commit` (работает в корневой директории)
- Позапускал `ruff` в обоих питон-проектах

Все работает 👍 