### PR TITLE
Get rid of relative imports

### DIFF
--- a/backend/backend/apps/bookings/admin.py
+++ b/backend/backend/apps/bookings/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Booking
+from backend.apps.bookings.models import Booking
 
 
 @admin.register(Booking)

--- a/backend/backend/apps/bookings/urls.py
+++ b/backend/backend/apps/bookings/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import BookingCreateView, FreeBookingTimeView
+from backend.apps.bookings.views import BookingCreateView, FreeBookingTimeView
 
 app_name = "bookings"
 

--- a/backend/backend/apps/core/admin.py
+++ b/backend/backend/apps/core/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import SaunaConfig
+from backend.apps.core.models import SaunaConfig
 
 
 @admin.register(SaunaConfig)

--- a/backend/backend/apps/core/serializers.py
+++ b/backend/backend/apps/core/serializers.py
@@ -2,7 +2,7 @@ import datetime
 
 from rest_framework import serializers
 
-from .models import SaunaConfig
+from backend.apps.core.models import SaunaConfig
 
 TIME_FORMAT = "%H:%M"
 

--- a/backend/backend/apps/core/urls.py
+++ b/backend/backend/apps/core/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import ConfigView
+from backend.apps.core.views import ConfigView
 
 app_name = "core"
 

--- a/backend/backend/apps/customers/admin.py
+++ b/backend/backend/apps/customers/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Customer
+from backend.apps.customers.models import Customer
 
 
 @admin.register(Customer)

--- a/backend/backend/apps/inventory/admin.py
+++ b/backend/backend/apps/inventory/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import InventoryItem
+from backend.apps.inventory.models import InventoryItem
 
 
 @admin.register(InventoryItem)

--- a/backend/backend/apps/inventory/urls.py
+++ b/backend/backend/apps/inventory/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import InventoryView
+from backend.apps.inventory.views import InventoryView
 
 app_name = "inventory"
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -45,9 +45,13 @@ lint.select = [
     "SIM",
     "PT",
     "TCH",
-    "ANN" # flake8-annotations
+    "ANN",
+    "TID",
 ]
 lint.ignore = ["E203", "E501"]  # comparable with Black
 
 [format]
 quote-style = "double"
+
+[lint.flake8-tidy-imports]
+ban-relative-imports = "all"


### PR DESCRIPTION
## Что сделал

- Добавил в конфиг `ruff` правило `TID`. Там 3 правила, мне нужно было только то, которое запрещает относительные импорты.
- Заменил все относительные импорты в проекте на абсолютные

## Почему

В проекте была неопределенность на эту тему. В соседних файлах один и тот же класс мог импортироваться по-разному:
```python
# В одном файле
from backend.apps.core.models import SaunaConfig

# В другом
from .models import SaunaConfig
```

Также (еще в башне) мы обсуждали, какие лучше делать иморты и сошлись на абсолютных. И недавно @ErroX1 напомнил об этом. Я решил увековечить это решение в конфиге `ruff`. Теперь все импорты должны быть абсолюными.