### PR TITLE
Fix django admin booking creation error

### DIFF
--- a/backend/backend/apps/bookings/models.py
+++ b/backend/backend/apps/bookings/models.py
@@ -1,6 +1,11 @@
 import datetime as dt
 
-from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.exceptions import (
+    NON_FIELD_ERRORS,
+)
+from django.core.exceptions import (
+    ValidationError as DjangoValidationError,
+)
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -51,7 +56,7 @@ class Booking(models.Model):
         errors = {}
 
         if self.start_datetime > self.end_datetime:
-            errors.setdefault("non_field_errors", []).append(
+            errors.setdefault(NON_FIELD_ERRORS, []).append(
                 DjangoValidationError(
                     _("The start time must be before the end time."),
                     code="start_time_after_end",
@@ -63,7 +68,7 @@ class Booking(models.Model):
             )
 
         if self.start_datetime - now < dt.timedelta(seconds=0):
-            errors.setdefault("non_field_errors", []).append(
+            errors.setdefault(NON_FIELD_ERRORS, []).append(
                 DjangoValidationError(
                     _("Booking date cannot be in the past."),
                     params={
@@ -75,7 +80,7 @@ class Booking(models.Model):
             )
 
         elif self.start_datetime - now < sauna_config.min_time_from_now_to_booking:
-            errors.setdefault("non_field_errors", []).append(
+            errors.setdefault(NON_FIELD_ERRORS, []).append(
                 DjangoValidationError(
                     _(
                         f"There must be at least {sauna_config.min_time_from_now_to_booking} "
@@ -91,7 +96,7 @@ class Booking(models.Model):
             )
 
         if self.end_datetime - self.start_datetime < sauna_config.min_booking_time:
-            errors.setdefault("non_field_errors", []).append(
+            errors.setdefault(NON_FIELD_ERRORS, []).append(
                 DjangoValidationError(
                     _(
                         f"{sauna_config.min_booking_time} is the minimal booking duration."
@@ -108,7 +113,7 @@ class Booking(models.Model):
         if not sauna_config.is_booking_within_open_hours(
             self.start_datetime, self.end_datetime
         ):
-            errors.setdefault("non_field_errors", []).append(
+            errors.setdefault(NON_FIELD_ERRORS, []).append(
                 DjangoValidationError(
                     _("The booking time goes beyond the opening hours."),
                     code="outside_opening_hours",
@@ -122,7 +127,7 @@ class Booking(models.Model):
             )
 
         if not self.is_booking_time_available():
-            errors.setdefault("non_field_errors", []).append(
+            errors.setdefault(NON_FIELD_ERRORS, []).append(
                 DjangoValidationError(
                     _(
                         f"Bookings overlap with the existing one or there is not enough buffer in "

--- a/backend/backend/apps/bookings/serializers.py
+++ b/backend/backend/apps/bookings/serializers.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import NON_FIELD_ERRORS
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.utils.timezone import get_default_timezone
@@ -11,6 +12,8 @@ from backend.services.customer_service import handle_customer_visit
 from backend.services.inventory_service import (
     process_booking_items,
 )
+
+EXTERNAL_NON_FIELD_ERRORS = "non_field_errors"
 
 
 class TimeSlotSerializer(serializers.Serializer):
@@ -50,6 +53,11 @@ class BookingSerializer(serializers.Serializer):
 
         if hasattr(e, "error_dict"):
             for field, errors in e.error_dict.items():
+                # convert django's "__all__" to our "non_field_errors"
+                field = (
+                    EXTERNAL_NON_FIELD_ERRORS if field == NON_FIELD_ERRORS else field
+                )
+
                 formatted[field] = []
                 for err in errors:
                     formatted[field].append(
@@ -61,9 +69,9 @@ class BookingSerializer(serializers.Serializer):
                     )
 
         elif hasattr(e, "error_list"):
-            formatted["non_field_errors"] = []
+            formatted[EXTERNAL_NON_FIELD_ERRORS] = []
             for err in e.error_list:
-                formatted["non_field_errors"].append(
+                formatted[EXTERNAL_NON_FIELD_ERRORS].append(
                     {
                         "message": str(err.message),
                         "code": err.code,


### PR DESCRIPTION
# В чем была проблема

Если в админке создавать бронь и допустить ошибку, которую обработал бы метод `Booking.clean`, появляется такая ошибка (вставлю все для истории):
```
Traceback (most recent call last):
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/forms/models.py", line 498, in _post_clean
    self.instance.full_clean(exclude=exclude, validate_unique=False)
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/db/models/base.py", line 1679, in full_clean
    raise ValidationError(errors)
django.core.exceptions.ValidationError: {'non_field_errors': ['2:00:00 is the minimal booking duration.']}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/contrib/admin/options.py", line 719, in wrapper
    return self.admin_site.admin_view(view)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/utils/decorators.py", line 192, in _view_wrapper
    result = _process_exception(request, e)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/utils/decorators.py", line 190, in _view_wrapper
    response = view_func(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/views/decorators/cache.py", line 80, in _view_wrapper
    response = view_func(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/contrib/admin/sites.py", line 246, in inner
    return view(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/contrib/admin/options.py", line 1987, in change_view
    return self.changeform_view(request, object_id, form_url, extra_context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/utils/decorators.py", line 48, in _wrapper
    return bound_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/utils/decorators.py", line 192, in _view_wrapper
    result = _process_exception(request, e)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/utils/decorators.py", line 190, in _view_wrapper
    response = view_func(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/contrib/admin/options.py", line 1843, in changeform_view
    return self._changeform_view(request, object_id, form_url, extra_context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/contrib/admin/options.py", line 1888, in _changeform_view
    form_validated = form.is_valid()
                     ^^^^^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/forms/forms.py", line 206, in is_valid
    return self.is_bound and not self.errors
                                 ^^^^^^^^^^^
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/forms/forms.py", line 201, in errors
    self.full_clean()
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/forms/forms.py", line 339, in full_clean
    self._post_clean()
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/forms/models.py", line 500, in _post_clean
    self._update_errors(e)
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/forms/models.py", line 472, in _update_errors
    self.add_error(None, errors)
  File "/Users/eevandeya/Library/Caches/pypoetry/virtualenvs/fortunahub-backend-VsdW-aH0-py3.12/lib/python3.12/site-packages/django/forms/forms.py", line 301, in add_error
    raise ValueError(
ValueError: 'BookingForm' has no field named 'non_field_errors'.
```

Проблема в ключе, отвечающем за ошибки, не связанные с конкретным полем. До этого я его переименовывал в `"non_field_errors"`, но где-то внутри django этот ключ обозначается `"__all__"`. В связи с этим в нашем случае происходит какая-то ошибка в формах джанго.

Вывод, который мы можем сделать - метод `clean` должен возвращать ошибки с ключем `"__all__"`.

# Как исправил

- В `clean` импортировал ключ (строку) прямо из `django.core.exceptions`
- Изменил `format_validation_error` так, чтобы поле `__all__` переименовывалось в `non_field_errors`, для красоты, как и было до этого.

